### PR TITLE
Refactor of JWT authentication stuff: tokens now have a model

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,55 +4,59 @@ class ApplicationController < ActionController::API
   private
 
   def authenticate_request
-    token_payload = decode_token_from_header
+    token_string = unpack_token_from_header
 
-    if token_payload
-      # because the token was signed by us, we can trust it
-      @token = token_payload
-      return true
-    else
-      render json: { "errors" => # json:api format
-          [{
-            "title" => "No Auth Token",
-            "detail" => "Either: a JWT token was not included in the Authorization HTTP header; the header was malformed; or the token is invalid or corrupt.",
-          }]
-        },
-        status: 401
+    if (token_string == false || token_string.nil?)
+      return false
     end
 
+    token = Token.new_from_jwt_string(token_string)
+    if (token.valid?)
+      @token = token
+      return true
+    else
+      if (token.errors?)
+        render json: { # json:api format
+          "errors" => token.errors
+        }, status: 401
+      else
+        render json: { "errors" =>
+          [{
+            "title" => "Unknown token error",
+            "detail" => "The JWT token you gave was invalid, but no more specific error is known."
+          }]
+        }, status: 401
+      end
+      return false
+    end
   end
 
-  def decode_token_from_header
+  def unpack_token_from_header
     if request.headers['Authorization'].present?
       header = request.headers['Authorization']
       regex = /^Bearer (.*)/
       encoded_token_string = header[regex, 1]
-      
+
       if (encoded_token_string.nil?)
-        return nil
+        render json: { "errors" =>
+          [{
+            "title" => "No JWT token in header",
+            "detail" => "The server's string processing facilities failed to see a token (prefixed by 'Bearer ') in the Authorization header."
+          }]
+        }, status: 401
+        return false
       end
 
-      # in proper use we'd fetch the secret from a conf file or
-      # environment variable instead of hardcoding it into the program
-      secret = Rails.configuration.jwt_secret
-
-      decoded_token = JWT.decode(encoded_token_string, secret, true, {:algorithm => 'HS256'})
-      # the format:
-      # [{"tmcusr"=>  "username", "tmctok"=>"ABCD", "exp"=>1500000000}, {"typ"=>"JWT", "alg"=>"HS256"}]
-      #Rails.logger.debug(decoded_token.inspect)
-
-      token_payload = decoded_token[0]
-      return token_payload
+      return encoded_token_string
+    else
+      render json: { "errors" =>
+        [{
+          "title" => "Missing 'Authorization' header",
+          "detail" => "This resource requires a valid JSON Web Token signed by this server."
+        }]
+      }, status: 401
+      return false
     end
-    rescue JWT::VerificationError
-      
-      render json: { "errors" => # json:api format
-          [{
-            "title" => "Invalid Auth Token",
-            "detail" => "Either: a JWT token was not included in the Authorization HTTP header; the header was malformed; or the token is invalid or corrupt. (Verification Error)",
-          }]
-        },
-        status: 401
   end
 
 end

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -1,96 +1,35 @@
 class TokensController < ApplicationController
-  require 'jwt'
-  require 'net/http' # since ruby 2.4.1 "require 'net/https'" isn't necessary
-  require 'json'
 
   skip_before_action :authenticate_request
 
   def newtoken
     Rails.logger.info("JWT secret for this session: \"" + Rails.configuration.jwt_secret + '"')
 
+    #Rails.logger.debug("Token methods: " + Token.methods.sort.inspect)
+
     tmc_username = params[:tmc_username]
     tmc_access_token = params[:tmc_access_token]
 
-    # here we would try logging in to the TMC server with the given
-    # access token, fetching user information from the server, and checking
-    # that the returned username matches the given username.
+    token = Token.new_from_credentials(tmc_username, tmc_access_token)
 
-    usernames_match = verify_given_credentials(tmc_username, tmc_access_token)
-
-    if (usernames_match)
-      expiry = 24.hours.from_now.to_i
-      secret = Rails.configuration.jwt_secret
-      token_payload = {
-        tmcusr: tmc_username,
-        tmctok: tmc_access_token,
-        exp: expiry
-      }
-      token_string = JWT.encode(token_payload, secret, 'HS256')
+    if (token.errors?)
+      render json: { # json:api format
+        "errors" => token.errors
+      }, status: 401
+    elsif (!token.valid?)
+      render json: { "errors" =>
+        [{
+          "title" => "Just-generated JWT token is invalid",
+          "detail" => "Not sure why the token would be invalid but there weren't any other errors. The token anyway: " + token.jwt
+        }]
+      }, status: 401
+    else
       render json: {
-        data: {
-          token: token_string
+        "data" => {
+          "token" => token.jwt,
+          "expires_at" => token.expires.to_i
         }
       }
-    else
-      render json: { "errors" => # json:api format
-          [{
-            "title" => "Invalid Credentials",
-            "detail" => "Either: you did not pass a tmc_username and tmc_access_token; the tmc_access_token did not work for accessing the TMC API; or the tmc_username did not match that returned by the TMC API when asked with the tmc_access_token.",
-          }]
-        },
-        status: 401 # unauthorized
-    end
-  end
-
-  def verify_given_credentials(given_username, acctok)
-    api_call_result = do_tmc_api_get('/users/current', acctok);
-
-    if (api_call_result[:success])
-      response_hash = api_call_result[:body]
-      # The TMC server would have returned JSON of this format:
-      # {"id":1234,"username":"asdf","email":"asdf@asdf","administrator":false}
-      # and response_hash would be the Ruby equivalent of this.
-      returned_username = response_hash['username'];
-      if (given_username != returned_username)
-        Rails.logger.debug("verify_given_credentials: given_username != returned_username");
-        return false;
-      else
-        return true;
-      end
-    else
-      Rails.logger.debug("verify_given_credentials: do_tmc_api_get didn't work");
-      return false;
-    end
-
-  end
-
-  # returns a hash structured thusly:
-  # { :success => true/false, :code => <http response code>, :body => <decoded JSON response from api> }
-  def do_tmc_api_get(endpoint, access_token)
-    tmc_api_base_address = Rails.configuration.tmc_api_base_address
-    tmc_api_endpoint = "/users/current"
-    full_api_call_address = tmc_api_base_address + tmc_api_endpoint
-
-    authtokenstring = 'Bearer ' + access_token
-
-    uri = URI.parse(full_api_call_address)
-    request = Net::HTTP::Get.new(uri)
-    request['Authorization'] = authtokenstring
-    #Rails.logger.debug("HTTP::Get object's headers:");
-    #request.each_header { |h, v| Rails.logger.debug("\t" + h + ": " + v) }
-
-    response = Net::HTTP.start(uri.hostname, uri.port,
-        :use_ssl => true, :verify_mode => OpenSSL::SSL::VERIFY_PEER) { |http|
-      http.request(request)
-    }
-
-    if (response.code.to_s == "200")
-      response_hash = JSON.parse(response.body);
-      return_hash = { :success => true, :code => response.code, :body => response_hash }
-      return return_hash
-    else
-      Rails.logger.debug("do_tmc_api_get: GET to " + full_api_call_address + " returned code " + response.code.inspect + " (!= 200). Response body: " + response.body);
-      return_hash = { :success => false, :code => response.code, :body => response.body}
     end
   end
 

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -1,0 +1,238 @@
+class Token
+  require 'jwt'
+  require 'json'
+  require 'net/http' # since ruby 2.4.1 "require 'net/https'" isn't necessary
+
+  JWT_HASH_ALGO = 'HS256'
+  @@jwt_secret = Rails.configuration.jwt_secret;
+  @@verify_tmc_creds = Rails.configuration.jwt_verify_tmc_credentials;
+
+  def initialize
+    @errors = Array.new
+    @invalidated = true
+    @tested = false
+    @expires = 0
+    @username = ""
+    @tmc_token = ""
+    @jwt = ""
+  end
+
+  def self.new_from_credentials(username, tmc_access_token)
+    token = Token.new
+    token.initialize_from_credentials(username, tmc_access_token)
+    return token
+  end
+
+  def self.new_from_jwt_string(jwt)
+    token = Token.new
+    token.initialize_from_jwt_string(jwt)
+    return token
+  end
+
+  def initialize_from_credentials(username, tmc_access_token, verify_creds = @@verify_tmc_creds)
+    @username = username
+    @tmc_token = tmc_access_token
+    @expires = Time.now + 86400
+    @tested = false
+    @invalidated = false
+    @jwt_string = make_jwt
+
+    if (verify_creds)
+      verification_result = verify_given_credentials(@username, @tmc_token)
+      if (verification_result == true)
+        @tested = true
+      else
+        # We invalidate the token when it was checked for validity but didn't
+        # pass the check. We don't invalidate it if it wasn't supposed to be
+        # checked in the first place, which is why this statement is here
+        # and not, for instance, in an else-branch of if(verify_creds).
+        @invalidated = true
+        # verify_given_credentials will set an error, so we don't need
+        # to do so here.
+      end
+    end
+  end
+
+  def initialize_from_jwt_string(jwt)
+    @jwt_string = jwt
+
+    decoded_token = JWT.decode(jwt, @@jwt_secret, true, {:algorithm => JWT_HASH_ALGO})
+    # The format of what JWT.decode returns:
+    # [ {"tmcusr"=>  "username", "tmctok"=>"ABCD", "exp"=>1500000000},
+    #   {"typ"=>"JWT", "alg"=>"HS256"} ]
+    # Rails.logger.debug(decoded_token.inspect)
+
+    token_payload = decoded_token[0]
+    if (!token_payload.nil?)
+      @username = token_payload["tmcusr"]
+      @tmc_token = token_payload["tmctok"]
+      @expires = token_payload["exp"]
+      @invalidated = self.expired?
+      @tested = @@verify_tmc_creds
+    end
+  rescue JWT::VerificationError
+    error = {
+      "title" => "Token verification error",
+      "detail" => "The token is invalid, corrupt, or maliciously created, as it does not pass signature verification.",
+    }
+    @errors.push(error)
+    @invalidated = true
+    @tested = false
+  rescue JWT::DecodeError
+    error = {
+      "title" => "Malformed token",
+      "detail" => "The JWT token given is incorrectly formed and cannot be decoded.",
+    }
+    @errors.push(error)
+    @invalidated = true
+    @tested = false
+  end
+
+
+  def username
+    @username
+  end
+
+  def tmc_token
+    @tmc_token
+  end
+
+  def expires
+    @expires
+  end
+
+  def jwt
+    @jwt_string
+  end
+
+  def errors?
+    return !(@errors.empty?)
+  end
+
+  def errors
+    return @errors
+  end
+
+  def valid?
+    # The class variable @invalidated exists because we might want to define
+    # the token as invalid despite it not having expired yet; for instance, if
+    # signature verification has failed, or if the application configuration
+    # demands usernames and access tokens are tested and the given ones have
+    # failed such a test.
+    return !(@invalidated | self.expired?)
+  end
+
+  # "Tested" is different from "valid" in that a token is valid if it isn't
+  # expired or hasn't been invalidated for another reason, but is tested
+  # only if:
+  # 1) When the Token object was created with new_from_credentials, the
+  #    config setting Rails.configuration.jwt_verify_tmc_credentials is true,
+  #    and the "given credentials" were successfully used to log in to the
+  #    TMC server.
+  # 2) When the Token object was created with new_from_jwt_string, the config
+  #    setting Rails.configuration.jwt_verify_tmc_credentials is true. The
+  #    assumption is that if jwt_verify_tmc_credentials is true now, it was
+  #    true when the JWT token was created and signed, and the TMC credentials
+  #    contained within the JWT token were successfully used to log in to the
+  #    TMC server back then.
+  # So, for development purposes, a token that isn't tested but is valid
+  # might be acceptable, but a token that isn't valid is never OK.
+  def tested?
+    @tested
+  end
+
+
+  def expired?
+    now = Time.now
+    # We add one minute to expiry time to account for possible clock drift,
+    # as allowed by RFC 7519 (the JWT standard)
+    exp = Time.at(@expires) + 60
+    # (a<=>b)>0 because Time doesn't define > itself
+    expired = (now <=> exp) > 0
+    if (expired)
+      error = {
+        :title => "Expired JWT token",
+        :detail => "The expiration time specified in the JWT token body has elapsed."
+      }
+      # Let's not push a new identical error on the error pile.
+      unless (@errors.include?(error))
+        @errors.push(error)
+      end
+    end
+  end
+
+  # returns a hash structured thusly:
+  # { :success => true/false, :code => <http response code>, :body => <decoded JSON response from api> }
+  def do_tmc_api_get(endpoint, access_token)
+    tmc_api_base_address = Rails.configuration.tmc_api_base_address
+    tmc_api_endpoint = "/users/current"
+    full_api_call_address = tmc_api_base_address + tmc_api_endpoint
+
+    authtokenstring = 'Bearer ' + access_token
+
+    uri = URI.parse(full_api_call_address)
+    request = Net::HTTP::Get.new(uri)
+    request['Authorization'] = authtokenstring
+    #Rails.logger.debug("HTTP::Get object's headers:");
+    #request.each_header { |h, v| Rails.logger.debug("\t" + h + ": " + v) }
+
+    response = Net::HTTP.start(uri.hostname, uri.port,
+        :use_ssl => true, :verify_mode => OpenSSL::SSL::VERIFY_PEER) { |http|
+      http.request(request)
+    }
+
+    if (response.code.to_s == "200")
+      response_hash = JSON.parse(response.body);
+      return_hash = { :success => true, :code => response.code, :body => response_hash }
+      return return_hash
+    else
+      Rails.logger.debug("do_tmc_api_get: GET to " + full_api_call_address + " returned code " + response.code.inspect + " (!= 200). Response body: " + response.body);
+      return_hash = { :success => false, :code => response.code, :body => response.body}
+    end
+  end
+
+
+  private
+
+
+  def make_jwt
+    token_payload = {
+      "tmcusr" => @username,
+      "tmctok" => @tmc_token,
+      "exp" => @expires.to_i
+    }
+    jwt_string = JWT.encode(token_payload, @@jwt_secret, JWT_HASH_ALGO)
+    return jwt_string
+  end
+
+
+  def verify_given_credentials(given_username, tmc_access_token)
+    api_call_result = do_tmc_api_get('/users/current', tmc_access_token);
+
+    if (api_call_result[:success])
+      response_hash = api_call_result[:body]
+      # The TMC server would have returned JSON of this format:
+      # {"id":1234,"username":"asdf","email":"asdf@asdf","administrator":false}
+      # and response_hash would be the Ruby equivalent of this.
+      returned_username = response_hash['username'];
+      if (given_username != returned_username)
+        error = {
+          "title" => "Credential verification failed",
+          "detail" => "The given TMC credentials were tested, and the result was negative: the given username does not match the username returned by the TMC server."
+        }
+        @errors.push(error)
+        return false;
+      else
+        return true;
+      end
+    else
+      error = {
+        "title" => "Unable to verify credentials",
+        "detail" => "Verification of the given TMC credentials failed when accessing the TMC server. (Perhaps the given TMC access token is invalid.) Server response: " + api_call_result[:code] + "\n" + api_call_result[:body]
+      }
+      @errors.push(error)
+      return false;
+    end
+  end
+
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,6 @@ module DashboardBackend
     six_digit_hex_string = "%06x" % Random::rand(65536 * 256)
     config.jwt_secret = six_digit_hex_string.upcase
 
+    config.jwt_verify_tmc_credentials = true
   end
 end


### PR DESCRIPTION
This commit merges the JWT creation and verification code from `application_controller` and `tokens_controller` into a model, `token.rb`. The basic `application_controller` and the `token_controller` are thus simplified, only tasked with moving data to and from the `token` model and rendering errors.