### PR TITLE
Course endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  get '/cumulative-points', to: 'cumulative_points#cumulative_point_current'
-  get '/skill-percentages', to: 'mastery_percentages#skill_percentage_current'
+  get '/cumulative-points/course/:course_id', to: 'cumulative_points#cumulative_point_current'
+  get '/skill-percentages/course/:course_id', to: 'mastery_percentages#skill_percentage_current'
   post '/new-dash-session', to: 'tokens#newtoken'
 
   get '/leaderboard/course/:course_id', to: 'leaderboards#get_range'

--- a/spec/controllers/cumulative_points_controller_spec.rb
+++ b/spec/controllers/cumulative_points_controller_spec.rb
@@ -7,7 +7,7 @@ describe CumulativePointsController do
     before do
       jwt_token
 
-      get '/cumulative-points'
+      get '/cumulative-points/course/214'
     end
 
     it 'responds with a 200 status' do

--- a/spec/controllers/mastery_percentage_controller_spec.rb
+++ b/spec/controllers/mastery_percentage_controller_spec.rb
@@ -7,7 +7,7 @@ describe MasteryPercentagesController do
     before do
       jwt_token
 
-      get '/skill-percentages'
+      get '/skill-percentages/course/214'
     end
 
     it 'responds with a 200 status' do


### PR DESCRIPTION
Add course ids to routes /cumulative-points and /skill-percentages so that frontend is able to send requests with course ids.