### PR TITLE
Fix cumulative points end point json content

### DIFF
--- a/app/controllers/cumulative_points_controller.rb
+++ b/app/controllers/cumulative_points_controller.rb
@@ -13,10 +13,6 @@ class CumulativePointsController < ApplicationController
     course_id = course_id.to_s
 
     cumulative_point = CumulativePoint.new(course_id, @token)
-    render json: { "data" => {
-        "user" => cumulative_point.day_point_objects,
-        "average" => cumulative_point.average_points_by_day
-      }
-    }
+    render json: { "data" => cumulative_point.day_point_objects }
   end
 end

--- a/app/models/cumulative_point.rb
+++ b/app/models/cumulative_point.rb
@@ -15,55 +15,28 @@ class CumulativePoint
   # Returns an array of {"day" => ..., "points" => ...} hashes
   def day_point_objects
     user_points = PointsHelper.users_own_points(@point_source, @course_id, @token.user_id)
+    all_points = PointsHelper.all_course_points(@point_source, @course_id)
+
     points_by_day = PointsHelper.daywise_points(user_points)
-    cumulative_points_by_day = cumulativize_points(points_by_day)
+    all_points_by_days = PointsHelper.daywise_points(all_points)
+
+    cumulative_all_points_by_day = cumulativize_points(all_points_by_days)
+
     return_data = Array.new
-    cumulative_points_by_day.each do |day, points|
-      return_data.push({"day" => day, "points" => points})
+    i = 0
+    points = 0
+    point_keys = points_by_day.keys
+    cumulative_all_points_by_day.each do |day, average|
+      if points_by_day[point_keys[i]].nil?
+        pointsIncrement = 0
+      else pointsIncrement = points_by_day[point_keys[i]]
+      end
+      points += pointsIncrement
+      return_data.push({"day" => day, "points" => points, "average" => average})
+      i += 1
     end
     return return_data
   end
-
-  def average_points_by_day
-    all_points = PointsHelper.all_course_points(@point_source, @course_id)
-    cumulative_points_by_day = cumulativize_points(PointsHelper.daywise_points(all_points))
-
-    # To calculate the daily average of points submitted, we need not
-    # the count of how many users submitted that day, nor the cumulative
-    # count of user-IDs who have submitted so far, but the maximum amount
-    # of unique users who received points.
-    daybuckets = Hash.new
-    # First, we chuck the users who submitted points into day-buckets.
-    all_points.each do |raw_point|
-      day = raw_point["awarded_point"]["created_at"].to_date
-      user_id = raw_point["awarded_point"]["user_id"]
-      daybuckets[day] = Array.new if (daybuckets[day].nil?)
-      daybuckets[day].push(user_id)
-    end
-    # Then, we cumulate the day-buckets, so that the bucket of day N
-    # also contains the contents of day-bucket N-1.
-    # We use cumulativize_points because it does exactly what we want:
-    # just mentally do s/points/daybuckets/
-    daybuckets = cumulativize_points(daybuckets)
-    # Then, we sort and uniq all the day-buckets, and finally,
-    # we grab the size of each day-bucket.
-    user_counts_by_day = PointsHelper.unique_bucket_count(daybuckets)
-
-    daily_average = Hash.new
-    days = user_counts_by_day.keys().sort()
-    days.each do |day|
-      points = cumulative_points_by_day[day].to_f
-      user_count = user_counts_by_day[day]
-      if (user_count == 0)
-        daily_average[day] = 0
-      else
-        daily_average[day] = points / user_count
-      end
-    end
-
-    return daily_average
-  end
-
 
   private
 

--- a/spec/controllers/cumulative_points_controller_spec.rb
+++ b/spec/controllers/cumulative_points_controller_spec.rb
@@ -22,41 +22,24 @@ describe CumulativePointsController do
       expect(last_response.status).to eq 200
     end
 
-    it 'returns json with "data" as the top element and "user" and "average" as sub-elements' do
-      #puts json.inspect
+    it 'returns json with "data" as the top element and "day", "point" and "average" as sub-elements' do
       expect(json["data"]).not_to be_nil
-      expect(json["data"]["user"]).not_to be_nil
-      expect(json["data"]["average"]).not_to be_nil
+      expect(json["data"][0]["day"]).not_to be_nil
+      expect(json["data"][0]["points"]).not_to be_nil
+      expect(json["data"][0]["average"]).not_to be_nil
     end
 
     it 'returns user-specific data' do
-      expect(json["data"]["user"].class == Array).to be(true)
+      expect(json["data"].class == Array).to be(true)
       # We know there is at least one point with UID=2, hence there must be
       # at least one point in here.
-      expect(json["data"]["user"].count > 0).to be(true)
+      expect(json["data"].count > 0).to be(true)
     end
 
-    it 'returns well-formed user-specific data' do
-      expect(json["data"]["user"][0]).not_to be_nil
-      expect(json["data"]["user"][0]["day"]).not_to be_nil
-      expect(json["data"]["user"][0]["points"]).not_to be_nil
-    end
-
-    it 'returns averages' do
-      expect(json["data"]["average"]).not_to be_nil
-      expect(json["data"]["average"].class == Hash).to be(true)
-      expect(json["data"]["average"].length > 0).to be(true)
-    end
-
-    it 'returns well-formed average data' do
-      keys = json["data"]["average"].keys
-      expect(json["data"]["average"][keys[0]]).not_to be_nil
-    end
-
-    it 'returns average data with Y-M-D dates as keys' do
+    it 'returns day in form of Y-M-D dates' do
       # String =~ Regexp returns nil if there's no match,
       # index of start of match if there is a match.
-      expect(json["data"]["average"].keys[0] =~ /^\d\d\d\d-\d\d-\d\d/).not_to be_nil
+      expect(json["data"][0]["day"] =~ /^\d\d\d\d-\d\d-\d\d/).not_to be_nil
     end
 
   end


### PR DESCRIPTION
Now renders e.g.:
{
    "data": [
        {
            "day": "2017-08-14",
            "points": 1,
            "average": 952
        },
        {
            "day": "2017-08-15",
            "points": 1,
            "average": 1000
        },
        {
            "day": "2017-08-16",
            "points": 1,
            "average": 1061
        },
        {
            "day": "2017-08-17",
            "points": 1,
            "average": 1101
        }
    ]
}