### PR TITLE
fixed reference in SkillMastery init_point_source method

### DIFF
--- a/app/models/skill_mastery.rb
+++ b/app/models/skill_mastery.rb
@@ -21,7 +21,7 @@ class SkillMastery
     Rails.logger.debug("PointsStore didn't have points of course #{@course_id},
     fetching...")
 
-    @point_source.update_course_points(@course_id, token) if
+    @point_source.update_course_points(@course_id, @token) if
       @point_source.course_point_update_needed?(@course_id)
   end
 


### PR DESCRIPTION
We should (probably) call point_source's update_course_points method with the instance variable @token instead of token that is undefined here and throws a NameError during the http request in case the point store is empty.